### PR TITLE
Fix for forge 2823+

### DIFF
--- a/src/main/java/chanceCubes/rewards/rewardparts/ItemPart.java
+++ b/src/main/java/chanceCubes/rewards/rewardparts/ItemPart.java
@@ -25,7 +25,8 @@ public class ItemPart extends BasePart
 		nbt.setString("id", stack.getItem().getRegistryName().toString());
 		nbt.setByte("Count", (byte) stack.getCount());
 		nbt.setShort("Damage", (short) stack.getItemDamage());
-		nbt.setTag("tag", stack.getTagCompound());
+		if (stack.hasTagCompound())
+			nbt.setTag("tag", stack.getTagCompound());
 		this.itemNBT = new NBTVar(nbt);
 		this.setDelay(delay);
 	}


### PR DESCRIPTION
Starting with forge 2823, calling setTag with null will throw an exception, which is causing the game to crash during startup.

https://github.com/MinecraftForge/MinecraftForge/commit/69a44e64142236a218c9cdea6b90f8a83143147c