### PR TITLE
Fixes a typo in the warning for Chance Cube.

### DIFF
--- a/src/main/java/chanceCubes/items/ItemChanceCube.java
+++ b/src/main/java/chanceCubes/items/ItemChanceCube.java
@@ -77,7 +77,7 @@ public class ItemChanceCube extends ItemBlock
 		if(item.equals(Item.getItemFromBlock(CCubesBlocks.COMPACT_GIANT_CUBE)))
 			list.add(new TextComponentString(TextFormatting.RED + "WARNING: The Giant Chance Cube will probably cause lots damage and/or place a lot of blocks down... You've been warned."));
 		else if(item.equals(Item.getItemFromBlock(CCubesBlocks.CHANCE_CUBE)))
-			list.add(new TextComponentString(TextFormatting.RED + "Warning: It is recommended you don't open these in or next toy your base."));
+			list.add(new TextComponentString(TextFormatting.RED + "Warning: It is recommended you don't open these in or next to your base."));
 	
 		if(item.equals(Item.getItemFromBlock(CCubesBlocks.CHANCE_CUBE)) /*|| item.equals(Item.getItemFromBlock(CCubesBlocks.CHANCE_ICOSAHEDRON))*/)
 		{


### PR DESCRIPTION
This pr intends to fix a tiny typo I just found in the ItemChanceCube addInformation method.

PS: this typo seems to be in every version of the mod